### PR TITLE
Add QA quality evaluation harness

### DIFF
--- a/exam_gen/__init__.py
+++ b/exam_gen/__init__.py
@@ -1,3 +1,6 @@
 """Exam generation package."""
 
 from .generate import generate_exam
+from .quality import evaluate
+
+__all__ = ["generate_exam", "evaluate"]

--- a/exam_gen/quality.py
+++ b/exam_gen/quality.py
@@ -1,0 +1,57 @@
+"""Evaluation utilities for generated Q/A pairs."""
+from __future__ import annotations
+
+import json
+import argparse
+from typing import Dict, List
+
+from . import retrieval
+
+
+def _token_overlap(text: str, reference: str) -> float:
+    """Compute ratio of words from text that appear in reference."""
+    tokens = text.lower().split()
+    if not tokens:
+        return 0.0
+    ref = reference.lower()
+    matches = sum(1 for t in tokens if t in ref)
+    return matches / len(tokens)
+
+
+def self_consistency(question: str, answer: str, context: str) -> float:
+    """Check that the answer is supported by the provided context."""
+    return _token_overlap(answer, context)
+
+
+def document_grounding(objective: str, answer: str) -> float:
+    """Verify the answer is grounded in retrieved documentation."""
+    results = retrieval.query(objective, k=3)
+    docs = " ".join(chunk for _, chunk in results)
+    return _token_overlap(answer, docs)
+
+
+def evaluate(qas: List[Dict]) -> float:
+    """Return average factual-consistency score for Q/A pairs."""
+    scores = []
+    for qa in qas:
+        obj = qa.get("objective", "")
+        answer = qa.get("answer", "")
+        question = qa.get("question", "")  # unused but kept for API
+        context = qa.get("context", "")
+        sc = self_consistency(question, answer, context)
+        dg = document_grounding(obj, answer)
+        scores.append((sc + dg) / 2)
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Evaluate generated exam JSON")
+    parser.add_argument("file", help="Path to exam JSON file")
+    args = parser.parse_args()
+
+    with open(args.file) as f:
+        data = json.load(f)
+
+    score = evaluate(data)
+    print(f"Score: {score:.2f}")
+

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,21 @@
+from exam_gen import db, embeddings
+from exam_gen.quality import evaluate
+
+
+def setup_module(module):
+    db.init_db()
+    db.clear()
+    chunk = "Terraform is an infrastructure as code tool."
+    db.insert_chunks("qa", [chunk], embeddings.embed_texts([chunk]))
+
+
+def test_evaluate():
+    qas = [{
+        "objective": "terraform",
+        "question": "What is Terraform?",
+        "answer": "Terraform is an infrastructure as code tool.",
+        "context": "Terraform is an infrastructure as code tool."
+    }]
+    score = evaluate(qas)
+    assert score >= 0.8
+


### PR DESCRIPTION
## Summary
- add `quality` module with evaluation utilities
- expose `evaluate` via package entry
- test evaluation routine

## Testing
- `pip install -q -r requirements.txt`
- `apt-get update`
- `apt-get install -y postgresql postgresql-16-pgvector`
- `service postgresql start`
- create user and database
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fcf1c38348323b63a14eb269c20e3