### PR TITLE
Implement W4 runbook and export utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ __pycache__/
 *.pyc
 *.sqlite
 *.log
-Dockerfile
+#Dockerfile
 *.pdf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ milestones will generate practice exam questions from this corpus.
    from exam_gen import retrieval
    print(retrieval.query("terraform backend"))
    ```
+## Runbook
+
+To create a practice exam and export it for Udemy:
+1. Provide a text file `objectives.txt` with one Terraform topic per line.
+2. Generate questions:
+   ```bash
+   python generate_dataset.py objectives.txt exam.json
+   ```
+3. Convert to Udemy CSV:
+   ```bash
+   python export_udemy.py exam.json udemy_questions.csv
+   ```
+4. Build a Docker image for distribution:
+   ```bash
+   docker build -t exam-generator .
+   ```
+
 
 ## Development
 

--- a/exam_gen/export.py
+++ b/exam_gen/export.py
@@ -1,0 +1,16 @@
+import csv
+from typing import List, Dict
+
+
+def to_udemy_csv(qas: List[Dict], path: str) -> None:
+    """Write Q/A pairs to a simplified Udemy-compatible CSV."""
+    fieldnames = ["Question", "Answer", "Explanation"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for qa in qas:
+            writer.writerow({
+                "Question": qa.get("question", ""),
+                "Answer": qa.get("answer", ""),
+                "Explanation": qa.get("explanation", ""),
+            })

--- a/export_udemy.py
+++ b/export_udemy.py
@@ -1,0 +1,20 @@
+import argparse
+import json
+
+from exam_gen.export import to_udemy_csv
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert exam JSON to Udemy CSV")
+    parser.add_argument("input", help="Input exam JSON file")
+    parser.add_argument("output", help="Output CSV path")
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        qas = json.load(f)
+
+    to_udemy_csv(qas, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -1,0 +1,23 @@
+import argparse
+import json
+
+from exam_gen.generate import generate_exam
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate exam JSON from objectives")
+    parser.add_argument("objectives", help="Text file with one objective per line")
+    parser.add_argument("output", help="Output JSON file")
+    parser.add_argument("-n", type=int, default=150, help="Number of questions to generate")
+    args = parser.parse_args()
+
+    with open(args.objectives) as f:
+        objs = [line.strip() for line in f if line.strip()]
+
+    qas = generate_exam(objs, n=args.n)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(qas, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,13 @@
+import csv
+from exam_gen.export import to_udemy_csv
+
+
+def test_to_udemy_csv(tmp_path):
+    qas = [{"question": "What is Terraform?", "answer": "A tool", "explanation": "IaC"}]
+    out = tmp_path / "out.csv"
+    to_udemy_csv(qas, out)
+    with open(out) as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["Question"] == "What is Terraform?"
+    assert rows[0]["Answer"] == "A tool"
+    assert rows[0]["Explanation"] == "IaC"


### PR DESCRIPTION
## Summary
- add new module for exporting Q/A pairs to Udemy CSV
- script to generate JSON dataset from objectives
- script to convert exam JSON to Udemy CSV
- Dockerfile for packaging the app
- document runbook steps in README
- test coverage for export logic

## Testing
- `pip install -q -r requirements.txt`
- `service postgresql start`
- `sudo -u postgres psql -c "CREATE USER exam WITH PASSWORD 'exam';" && sudo -u postgres psql -c "CREATE DATABASE exam OWNER exam;"`
- `sudo -u postgres psql exam -c "CREATE EXTENSION IF NOT EXISTS vector;"`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702805b3c48323b4858a9db41b39f2