### PR TITLE
Add MMR retrieval and distractor generation

### DIFF
--- a/exam_gen/agents.py
+++ b/exam_gen/agents.py
@@ -3,7 +3,7 @@
 from typing import Dict
 
 from . import retrieval
-from .llm import chat, chat_structured
+from .llm import chat, chat_structured, chat_list
 from .quality import evaluate
 
 
@@ -55,6 +55,33 @@ def answerer(state: Dict) -> Dict:
         "answer": resp.get("answer", ""),
         "explanation": resp.get("explanation", ""),
     }
+
+
+def distractor(state: Dict) -> Dict:
+    """Generate plausible but incorrect answers."""
+    context = state.get("context", "")
+    question = state.get("question", "")
+    answer = state.get("answer", "")
+
+    prompt = [
+        {
+            "role": "system",
+            "content": (
+                "Given the context, question, and correct answer, generate three "
+                "plausible but incorrect answers for a multiple-choice exam."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Context: {context}\nQuestion: {question}\nCorrect Answer: {answer}\n"
+                "Provide three wrong answers as a JSON list."
+            ),
+        },
+    ]
+
+    resp = chat_list(prompt)
+    return {"distractors": resp.get("distractors", [])}
 
 
 def reviewer(state: Dict) -> Dict:

--- a/exam_gen/retrieval.py
+++ b/exam_gen/retrieval.py
@@ -1,8 +1,50 @@
+from math import sqrt
+from typing import List, Tuple
+
 from .embeddings import embed_texts
 from . import db
 
 
-def query(text: str, k: int = 5):
+def _cosine(a: List[float], b: List[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sqrt(sum(x * x for x in a))
+    nb = sqrt(sum(y * y for y in b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _mmr(query_emb: List[float], cand_embs: List[List[float]], k: int, lambd: float = 0.5) -> List[int]:
+    """Return indices selected via Maximal Marginal Relevance."""
+    selected: List[int] = []
+    candidates = list(range(len(cand_embs)))
+    while candidates and len(selected) < k:
+        best_idx = candidates[0]
+        best_score = -1e9
+        for idx in candidates:
+            sim_to_query = _cosine(query_emb, cand_embs[idx])
+            sim_to_selected = max(
+                (_cosine(cand_embs[idx], cand_embs[j]) for j in selected), default=0
+            )
+            score = lambd * sim_to_query - (1 - lambd) * sim_to_selected
+            if score > best_score:
+                best_score = score
+                best_idx = idx
+        selected.append(best_idx)
+        candidates.remove(best_idx)
+    return selected
+
+
+def query(text: str, k: int = 5) -> List[Tuple[str, str]]:
+    """Return ``k`` diverse chunks most relevant to ``text`` using MMR."""
+
     emb = embed_texts([text])[0]
-    return db.search(emb, top_k=k)
+    raw = db.search(emb, top_k=k * 4)
+    if not raw:
+        return []
+
+    chunks = [c for _, c in raw]
+    cand_embs = embed_texts(chunks)
+    idxs = _mmr(emb, cand_embs, k)
+    return [raw[i] for i in idxs]
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -17,3 +17,4 @@ def test_generate_exam():
     assert "question" in qa and qa["question"]
     assert "answer" in qa
     assert "explanation" in qa
+    assert "distractors" in qa and isinstance(qa["distractors"], list)

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -14,7 +14,12 @@ def test_evaluate():
         "objective": "terraform",
         "question": "What is Terraform?",
         "answer": "Terraform is an infrastructure as code tool.",
-        "context": "Terraform is an infrastructure as code tool."
+        "context": "Terraform is an infrastructure as code tool.",
+        "distractors": [
+            "A configuration language",
+            "A cloud service",
+            "A monitoring tool",
+        ],
     }]
     score = evaluate(qas)
     assert score >= 0.8


### PR DESCRIPTION
## Summary
- implement MMR based retrieval in `retrieval.py`
- add distractor agent and conditional graph logic
- extend quality evaluation for distractors
- add helper functions in `llm.py` for structured lists
- update tests for new behaviour

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d1e4adfc83239809aacb11ec5f8e